### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "@solana/wallet-adapter-wallets": "^0.15.5",
     "@solana/web3.js": "^1.37.0",
     "next": "12.1.2",
-    "react": "18.0.0",
-    "react-dom": "18.0.0"
+    "react": "17.0.0",
+    "react-dom": "17.0.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.23",


### PR DESCRIPTION
@solana/wallet-adapter-react@0.15.4 requires a peer dependency of react version ^17.0.0. And the project has a dependency of react@18.0.0.
this resulted in install error.

Downgrading the project react dependency to 17.0.0 resolves this issue.